### PR TITLE
Added kd3305pInstrument class, beep command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-# KA3305P
-Python3 library for USB serial control of the RND LAB 320-KA3305P power supply.
+# K(A/D)3305P
+Python3 library for USB serial control of the RND LAB 320-KA3305P/320-KD3305P power supply.
 
-The `ka3305pInstrument` class uses the python `serial` package which allows for communication with serial devices through `write` and `read`. The communication properties (BaudRate, Terminator, etc.) are set when invoking the serial object with `serial.Serial(...)`. For the RND LAB 320-KA3305P power supply: baud rate to 9600, 8 data bits, no parity, 1 stop bit. 
+## KA3305P
+
+The `ka3305pInstrument` class uses the python `serial` package which allows for communication with serial devices through `write` and `read`. The communication properties (BaudRate, Terminator, etc.) are set when invoking the serial object with `serial.Serial(...)`. For the RND LAB 320-KA3305P power supply: baud rate to 9600, 8 data bits, no parity, 1 stop bit.
+
+## KD3305P
+The `kd3305pInstrument` class is virtually identical to the class above, with the only difference being the channels being individually controllable, and the syntax of the serial commands being slightly different.
 
 ### Requires
 The following python packages are required by the class. 

--- a/ka3305.py
+++ b/ka3305.py
@@ -170,9 +170,9 @@ class ka3305pInstrument:
         Args:
             state (bool): True to turn on, False to turn off
         """
-        if(state == True):
+        if state:
             self.serWriteAndRecieve("OUT1")
-        elif(state == False):
+        else:
             self.serWriteAndRecieve("OUT0")
     
     def toggleOcp(self, state):
@@ -181,9 +181,9 @@ class ka3305pInstrument:
         Args:
             state (bool): True to turn on, False to turn off
         """
-        if(state == True):
+        if state:
             self.serWriteAndRecieve("OCP1")
-        elif(state == False):
+        else:
             self.serWriteAndRecieve("OCP0")
 
     def setOcp(self, channel, amp, delay=0.1):
@@ -204,9 +204,9 @@ class ka3305pInstrument:
         Args:
             state (bool): True to turn on, False to turn off
         """
-        if(state == True):
+        if state:
             self.serWriteAndRecieve("OVP1")
-        elif(state == False):
+        else:
             self.serWriteAndRecieve("OVP0")
 
     def setOvp(self, channel, voltage, delay=0.1):
@@ -265,11 +265,42 @@ class ka3305pInstrument:
         assert mode in self.modes, "Mode {} does not exist".format(mode)
         self.serWriteAndRecieve("TRACK{}".format(mode))
 
+
+class kd3305pInstrument(ka3305pInstrument):
+    def __init__(self, psu_com):
+        super().__init__(psu_com)
+
+    def setOut(self, state):
+        """Turns both outputs ON or OFF
+
+        Args:
+            state (bool): True to turn on, False to turn off
+        """
+        if state:
+            self.serWriteAndRecieve("OUT1:1\nOUT2:1")
+        else:
+            self.serWriteAndRecieve("OUT1:0\nOUT2:0")
+
+    def setOutCh(self, state, channel):
+        """Turns selected channel ON or OFF
+
+        Args:
+            state (bool): True to turn on, False to turn off
+            channel (int): Channel to set (either 1 or 2)
+        """
+
+        assert channel in self.channels, f"Channel {channel} does not exist"
+        if state:
+            self.serWriteAndRecieve(f"OUT{channel}:1")
+        else:
+            self.serWriteAndRecieve(f"OUT{channel}:0")
+
+
 if __name__ == "__main__":
     # This example is for Ubuntu, in Windows the port will most likely be COM*
     psu = ka3305pInstrument('/dev/ttyUSB0')
     # Connect to PSU
-    if psu.isConnected == True:
+    if psu.isConnected:
         # Get ID
         print(psu.getIdn())
         # Request voltage on channel 1

--- a/ka3305.py
+++ b/ka3305.py
@@ -294,6 +294,17 @@ class kd3305pInstrument(ka3305pInstrument):
             self.serWriteAndRecieve(f"OUT{channel}:1")
         else:
             self.serWriteAndRecieve(f"OUT{channel}:0")
+    
+    def setBeep(self, state):
+        """Turns beeper ON or OFF
+
+        Args:
+            state (bool): True to turn on, False to turn off
+        """
+        if state:
+            self.serWriteAndRecieve("BEEP1")
+        else:
+            self.serWriteAndRecieve("BEEP0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added `kd3305pInstrument` class to manage RND 320-KD3305P instrument; the main difference is mainly the syntax for turning the channels on/off, which they can also do independently. Also added "beep" control command.